### PR TITLE
Added image dimensions to info panel

### DIFF
--- a/Diffusion.Toolkit/Controls/PreviewPane.xaml
+++ b/Diffusion.Toolkit/Controls/PreviewPane.xaml
@@ -244,8 +244,28 @@
                                         <ColumnDefinition/>
                                         <ColumnDefinition Width="32"/>
                                     </Grid.ColumnDefinitions>
-                                    <TextBox Foreground="White" FontSize="14" BorderThickness="0"
+                                    <StackPanel Orientation = "Horizontal">
+                                        <TextBox Foreground="White" FontSize="14" BorderThickness="0"
                                              IsReadOnly="True" Padding="5" Background="Transparent" TextWrapping="WrapWithOverflow" Text="{Binding Date}"></TextBox>
+                                        <TextBlock>
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding Width}" Value="0">
+                                                            <Setter Property="Visibility" Value="Hidden"/>
+                                                        </DataTrigger>
+                                                        <DataTrigger Binding="{Binding Height}" Value="0">
+                                                            <Setter Property="Visibility" Value="Hidden"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                            <TextBlock Foreground="White" FontSize="14" Padding="15 5 0 0" Background="Transparent" TextWrapping="WrapWithOverflow" Text="{Binding Width}"></TextBlock>
+                                            <TextBlock Foreground="White" FontSize="14" Padding="0 4 0 0" Background="Transparent" TextWrapping="WrapWithOverflow" Text="x"></TextBlock>
+                                            <TextBlock Foreground="White" FontSize="14" Padding="0 5 5 0" Background="Transparent" TextWrapping="WrapWithOverflow" Text="{Binding Height}"></TextBlock>
+                                        </TextBlock>
+                                    </StackPanel>
                                     <Grid Opacity="0.5" Grid.Column="1"></Grid>
                                 </Grid>
                             </StackPanel>

--- a/Diffusion.Toolkit/Models/ImageViewModel.cs
+++ b/Diffusion.Toolkit/Models/ImageViewModel.cs
@@ -23,6 +23,8 @@ public class ImageViewModel : BaseNotify
     private string _otherParameters;
     private string _modelName;
     private string _date;
+    private int _width;
+    private int _height;
 
     private bool _favorite;
     private int? _rating;
@@ -74,11 +76,22 @@ public class ImageViewModel : BaseNotify
         set => SetField(ref _modelName, value);
     }
 
-
     public string Date
     {
         get => _date;
         set => SetField(ref _date, value);
+    }
+
+    public int Width
+    {
+        get => _width;
+        set => SetField(ref _width, value);
+    }
+
+    public int Height
+    {
+        get => _height;
+        set => SetField(ref _height, value);
     }
 
     public ICommand CopyPromptCommand

--- a/Diffusion.Toolkit/Pages/Search.xaml.cs
+++ b/Diffusion.Toolkit/Pages/Search.xaml.cs
@@ -639,6 +639,9 @@ namespace Diffusion.Toolkit.Pages
                 _model.CurrentImage.NegativePrompt = parameters.NegativePrompt;
                 _model.CurrentImage.OtherParameters = parameters.OtherParameters;
 
+                _model.CurrentImage.Width = parameters.Width;
+                _model.CurrentImage.Height = parameters.Height;
+
                 _model.CurrentImage.ModelHash = parameters.ModelHash;
                 _model.CurrentImage.Seed = parameters.Seed;
                 _model.CurrentImage.AestheticScore = $"{parameters.AestheticScore}";


### PR DESCRIPTION
_Full disclosure, I didn't see the dimensions listed in the "Other Parameters" until after I made this change. Though, this makes them easier to track when moving through images._

I added the dimensions to the bottom of the Info window next to the date. I was finding it a pain to look through and determine normal images from the Hi-Res ones. They will not show if either of the dimensions is 0 or non-existent.