### PR TITLE
Fix parsing of unquoted NaN values in HashCache file

### DIFF
--- a/Diffusion.Toolkit/MainWindow.xaml.cs
+++ b/Diffusion.Toolkit/MainWindow.xaml.cs
@@ -827,9 +827,9 @@ namespace Diffusion.Toolkit
                         }
                     }
                 }
-                catch (JsonException e)
+                catch (Exception e)
                 {
-                    MessageBox.Show($"Error parsing JSON file '{_settings.HashCache}':\n{e.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Information);
+                    MessageBox.Show($"Error loading JSON file '{_settings.HashCache}':\n{e.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Information);
                 }
 
                 //foreach (var model in _modelsCollection.ToList())


### PR DESCRIPTION
* Include the filename in the error message if parsing fails.
* Replace unquoted NaN strings with null.

I roughly tried to follow the similar fix added in commit https://github.com/RupertAvery/DiffusionToolkit/commit/c75a4489d4b53cd114f41dbed6c14d3bf13fad27.

fixes #155