### PR TITLE
Update Metadata.cs - fix aestheticScore write into the fileParameters structure

### DIFF
--- a/Diffusion.Scanner/Metadata.cs
+++ b/Diffusion.Scanner/Metadata.cs
@@ -146,7 +146,15 @@ public class Metadata
                     if (aestheticScore > 0)
                     {
                         fileParameters ??= new FileParameters();
-                        fileParameters.OtherParameters ??= $"aesthetic_score: {fileParameters.AestheticScore}";
+                        fileParameters.AestheticScore = aestheticScore;
+                        if(fileParameters.OtherParameters == null)
+                        {
+                            fileParameters.OtherParameters = $"aesthetic_score: {fileParameters.AestheticScore}";
+                        }
+                        else
+                        {
+                            fileParameters.OtherParameters += $"\naesthetic_score: {fileParameters.AestheticScore}";
+                        }
                     }
 
 
@@ -998,7 +1006,15 @@ public class Metadata
         if (aestheticScore > 0)
         {
             fileParameters ??= new FileParameters();
-            fileParameters.OtherParameters ??= $"aesthetic_score: {fileParameters.AestheticScore}";
+            fileParameters.AestheticScore = aestheticScore;
+            if(fileParameters.OtherParameters == null)
+            {
+                fileParameters.OtherParameters = $"aesthetic_score: {fileParameters.AestheticScore}";
+            }
+            else
+            {
+                fileParameters.OtherParameters += $"\naesthetic_score: {fileParameters.AestheticScore}";
+            }
         }
 
         return fileParameters;


### PR DESCRIPTION
Ensure fileParameters.AestheticScore is set if aestheticScore is set outside of the main A1111 chunk interpreter