### PR TITLE
Missing localisation keys for DateModified

### DIFF
--- a/Diffusion.Toolkit/Localization/default.json
+++ b/Diffusion.Toolkit/Localization/default.json
@@ -100,6 +100,7 @@
   "Search.RecycleBin": "Recycle Bin",
   "Search.SortBy": "Sort by:",
   "Search.SortBy.DateCreated": "Date Created",
+  "Search.SortBy.DateModified": "Date Modified",
   "Search.SortBy.Name": "Name",
   "Search.SortBy.Rating": "Rating",
   "Search.SortBy.AestheticScore": "Aesthetic Score",

--- a/Diffusion.Toolkit/Localization/en-US.json
+++ b/Diffusion.Toolkit/Localization/en-US.json
@@ -99,6 +99,7 @@
   "Search.RecycleBin": "Recycle Bin",
   "Search.SortBy": "Sort by:",
   "Search.SortBy.DateCreated": "Date Created",
+  "Search.SortBy.DateModified": "Date Modified",
   "Search.SortBy.Name": "Name",
   "Search.SortBy.Rating": "Rating",
   "Search.SortBy.AestheticScore": "Aesthetic Score",


### PR DESCRIPTION
I believe the localisation keys for Search.SortBy.DateModified were inadvertently overlooked for the default and en-US locale files. Prior to making these changes, this option was displaying as a raw key name on my copy.