### PR TITLE
Fix for "No such table: Image" while bulk search results action

### DIFF
--- a/Diffusion.Database/DataStore.Search.cs
+++ b/Diffusion.Database/DataStore.Search.cs
@@ -198,7 +198,8 @@ namespace Diffusion.Database
 
             var q = QueryBuilder.Filter(filter);
 
-            var count = db.ExecuteScalar<int>($"SELECT COUNT(*) FROM Image m1 {string.Join(' ', q.Joins)} WHERE {q.Item1}", q.Item2.ToArray());
+            string raw_query = $"SELECT COUNT(*) FROM Image m1 {string.Join(' ', q.Joins)} WHERE {q.Item1}";
+            var count = db.ExecuteScalar<int>(raw_query, q.Item2.ToArray());
 
             db.Close();
 
@@ -280,7 +281,8 @@ namespace Diffusion.Database
 
             var q = QueryBuilder.Filter(filter);
 
-            var images = db.Query<Image>($"SELECT Image.* FROM Image m1 {string.Join(' ', q.Joins)} WHERE {q.Item1}", q.Item2.ToArray());
+            string query_raw = $"SELECT m1.* FROM Image m1 {string.Join(' ', q.Joins)} WHERE {q.Item1}";
+            var images = db.Query<Image>(query_raw, q.Item2.ToArray());
 
             foreach (var image in images)
             {


### PR DESCRIPTION
@RupertAvery please verify this tiny PR.
Related to https://github.com/RupertAvery/DiffusionToolkit/issues/234#issuecomment-2439557202